### PR TITLE
Add `--set-as-main` flag support to repository bumper — `wazuh-dashboard-ml-commons`

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -154,6 +154,10 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
+          if [[ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]]; then
+             echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+             echo "No file changes from bumper (no PR created)."
+          fi
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -22,6 +22,11 @@ on:
         description: 'Optional identifier for the run'
         required: false
         type: string
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   bump:
@@ -76,6 +81,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
@@ -86,6 +92,11 @@ jobs:
             script_params="--version ${version} --stage ${stage}"
           elif [[ -z "$version" && -n "$stage" ]]; then
             script_params="--stage ${stage}"
+          fi
+
+          set_as_main=${{ env.SET_AS_MAIN }}
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params="${script_params} --set-as-main"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
@@ -102,7 +113,18 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected; skipping PR creation."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
@@ -110,6 +132,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -122,6 +145,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge
@@ -130,6 +154,6 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: https://github.com/${{ github.repository }}/pull/${{ steps.create_pr.outputs.pull_request_number }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/tools/README.md
+++ b/tools/README.md
@@ -70,8 +70,6 @@ This script automates the process of updating the version and stage in the Wazuh
 - `package.json`
 - `.github/workflows/5_builderpackage_ml_commons_plugin.yml` (only when not using `--set-as-main`)
 - `.github/workflows/5_builderprecompiled_base-dev-environment.yml` (only when not using `--set-as-main`)
-- `.github/workflows/unit-tests-workflow.yml` (only when not using `--set-as-main`)
-- `.github/workflows/lint-workflow.yml` (only when not using `--set-as-main`)
 
 ### Log
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,7 +7,7 @@ This script automates the process of updating the version and stage in the Wazuh
 ### Usage
 
 ```bash
-./repository_bumper.sh --version VERSION --stage STAGE [--tag] [--help]
+./repository_bumper.sh --version VERSION --stage STAGE [--tag] [--set-as-main] [--help]
 ```
 
 #### Parameters
@@ -23,6 +23,9 @@ This script automates the process of updating the version and stage in the Wazuh
 - `--tag`
   Generate a tag version format.
 
+- `--set-as-main`
+  Enables main branch mode: version values are updated while branch references pointing to `main` are preserved.
+
 - `--help`
   Shows help and exits.
 
@@ -31,6 +34,7 @@ This script automates the process of updating the version and stage in the Wazuh
 ```bash
 ./repository_bumper.sh --version 4.6.0 --stage alpha0
 ./repository_bumper.sh --version 4.6.0 --stage beta1
+./repository_bumper.sh --version 5.1.0 --stage alpha1 --set-as-main
 ./repository_bumper.sh --tag --stage alpha1
 ./repository_bumper.sh --tag
 ```
@@ -45,10 +49,13 @@ This script automates the process of updating the version and stage in the Wazuh
 4. **Updates the files**:
    - `VERSION.json`: Changes the `version` and `stage` fields.
    - `package.json`: Changes the `version` and `revision` fields inside the `wazuh` object.
-   - `.github/workflows/4_builderpackage_ml_commons_plugin.yml`: Updates the default value of the `reference` input.
+   - `.github/workflows/5_builderpackage_ml_commons_plugin.yml`: Updates the default value of the `reference` input.
    - `docker/imposter/wazuh-config.yml`: Updates the specFile URL with the new version.
    - `docker/imposter/api-info/api_info.json`: Updates the API version information.
-5. **Logs all actions** to a log file in the `tools` directory.
+5. **Handles branch reference replacements**:
+   - If `--set-as-main` is used, branch references to `main` are preserved.
+   - Otherwise, `main` references in supported workflows are replaced with the target version.
+6. **Logs all actions** to a log file in the `tools` directory.
 
 ### Notes
 
@@ -61,6 +68,10 @@ This script automates the process of updating the version and stage in the Wazuh
 - `CHANGELOG.md`
 - `VERSION.json`
 - `package.json`
+- `.github/workflows/5_builderpackage_ml_commons_plugin.yml` (only when not using `--set-as-main`)
+- `.github/workflows/5_builderprecompiled_base-dev-environment.yml` (only when not using `--set-as-main`)
+- `.github/workflows/unit-tests-workflow.yml` (only when not using `--set-as-main`)
+- `.github/workflows/lint-workflow.yml` (only when not using `--set-as-main`)
 
 ### Log
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -50,6 +50,7 @@ This script automates the process of updating the version and stage in the Wazuh
    - `VERSION.json`: Changes the `version` and `stage` fields.
    - `package.json`: Changes the `version` and `revision` fields inside the `wazuh` object.
    - `.github/workflows/5_builderpackage_ml_commons_plugin.yml`: Updates the default value of the `reference` input.
+  - `.github/workflows/5_builderprecompiled_base-dev-environment.yml`: Updates the default value of the `reference` input.
    - `docker/imposter/wazuh-config.yml`: Updates the specFile URL with the new version.
    - `docker/imposter/api-info/api_info.json`: Updates the API version information.
 5. **Handles branch reference replacements**:

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -502,8 +502,6 @@ update_branch_reference_defaults() {
   local files=(
     "${REPO_PATH}/.github/workflows/5_builderpackage_ml_commons_plugin.yml"
     "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
-    "${REPO_PATH}/.github/workflows/unit-tests-workflow.yml"
-    "${REPO_PATH}/.github/workflows/lint-workflow.yml"
   )
   local f
   for f in "${files[@]}"; do
@@ -512,12 +510,7 @@ update_branch_reference_defaults() {
       continue
     fi
     log "Replacing branch refs main with ${bump_string} in $f (where applicable)"
-    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
     sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
   done
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -16,6 +16,8 @@ VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
 TAG=false
+set_as_main=""
+skip_urls="no"
 CURRENT_VERSION=""
 
 # --- Helper Functions ---
@@ -29,7 +31,7 @@ log() {
 
 # Function to show usage
 usage() {
-  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo "Usage: $0 --version VERSION --stage STAGE [--tag] [--set-as-main] [--help]"
   echo ""
   echo "Parameters:"
   echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
@@ -37,6 +39,7 @@ usage() {
   echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
   echo "                      Required if --tag is not used"
   echo "  --tag               Generate a tag"
+  echo "  --set-as-main       Keep branch references pointing to main"
   echo "  --help              Display this help message"
   echo ""
   echo "Example:"
@@ -218,6 +221,10 @@ parse_arguments() {
       TAG=true
       shift
       ;;
+    --set-as-main)
+      set_as_main="yes"
+      shift 1
+      ;;
     --help)
       usage
       exit 0
@@ -229,6 +236,12 @@ parse_arguments() {
       ;;
     esac
   done
+
+  if [[ -n "$set_as_main" ]]; then
+    skip_urls="yes"
+  else
+    skip_urls="no"
+  fi
 }
 
 # Function to validate input parameters
@@ -479,6 +492,35 @@ update_manual_build_workflow() {
   log "Updating $WAZUH_DASHBOARD_ML_COMMONS_WORKFLOW_FILE workflow..."
 }
 
+update_branch_reference_defaults() {
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged"
+    return 0
+  fi
+
+  local bump_string="$VERSION"
+  local files=(
+    "${REPO_PATH}/.github/workflows/5_builderpackage_ml_commons_plugin.yml"
+    "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
+    "${REPO_PATH}/.github/workflows/unit-tests-workflow.yml"
+    "${REPO_PATH}/.github/workflows/lint-workflow.yml"
+  )
+  local f
+  for f in "${files[@]}"; do
+    if [ ! -f "$f" ]; then
+      log "WARNING: $f not found. Skipping main→${bump_string} default update."
+      continue
+    fi
+    log "Replacing branch refs main with ${bump_string} in $f (where applicable)"
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
+  done
+}
+
 # Function to update specFile URL in docker/imposter/wazuh-config.yml
 update_imposter_config() {
   local new_version="$1"
@@ -560,6 +602,12 @@ main() {
   # Compare versions and determine revision
   compare_versions_and_set_revision
 
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "Main branch mode enabled: version values will be updated and branch references will remain pointing to main."
+  else
+    log "Freeze mode enabled: version values and branch references will be updated."
+  fi
+
   # Start file modifications
   log "Starting file modifications..."
 
@@ -567,6 +615,7 @@ main() {
   update_package_json
   update_changelog
   update_manual_build_workflow
+  update_branch_reference_defaults
 
   # Update docker/imposter/wazuh-config.yml
   # log "Updating docker/imposter/wazuh-config.yml..."

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -16,8 +16,8 @@ VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
 TAG=false
-set_as_main=""
-skip_urls="no"
+SET_AS_MAIN=""
+SKIP_URLS="no"
 CURRENT_VERSION=""
 
 # --- Helper Functions ---
@@ -222,7 +222,7 @@ parse_arguments() {
       shift
       ;;
     --set-as-main)
-      set_as_main="yes"
+      SET_AS_MAIN="yes"
       shift 1
       ;;
     --help)
@@ -237,10 +237,10 @@ parse_arguments() {
     esac
   done
 
-  if [[ -n "$set_as_main" ]]; then
-    skip_urls="yes"
+  if [[ -n "$SET_AS_MAIN" ]]; then
+    SKIP_URLS="yes"
   else
-    skip_urls="no"
+    SKIP_URLS="no"
   fi
 }
 
@@ -493,7 +493,7 @@ update_manual_build_workflow() {
 }
 
 update_branch_reference_defaults() {
-  if [[ "$skip_urls" == "yes" ]]; then
+  if [[ "$SKIP_URLS" == "yes" ]]; then
     log "skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged"
     return 0
   fi
@@ -595,7 +595,7 @@ main() {
   # Compare versions and determine revision
   compare_versions_and_set_revision
 
-  if [[ "$skip_urls" == "yes" ]]; then
+  if [[ "$SKIP_URLS" == "yes" ]]; then
     log "Main branch mode enabled: version values will be updated and branch references will remain pointing to main."
   else
     log "Freeze mode enabled: version values and branch references will be updated."


### PR DESCRIPTION
### Description
This PR adds support for the --set-as-main flag in this repository's bumper files as part of the two-step version bump flow from main.

If the --set-as-main flag is not set, it will update the references to main branch to the specified version, if its set, it will skip that step.

### Issues Resolved
- **Issue:** https://github.com/wazuh/wazuh-dashboard-ml-commons/issues/30

### Evidence:

<details><summary>Running: <code>./tools/repository_bumper.sh  --version 5.1.0 --stage alpha1 </code></summary>
<p>

```bash
wazuh-dashboard-ml-commons change/30-add-set-as-main-flag-support-to-repository-bumper-wazuh-dashboard-ml-commons ❯ ./tools/repository_bumper.sh --version 5.1.0 --stage alpha1
[2026-03-30 12:13:19] Starting repository bump process
[2026-03-30 12:13:19] Repository path: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons
[2026-03-30 12:13:19] Version: 5.1.0
[2026-03-30 12:13:19] Stage: alpha1
[2026-03-30 12:13:19] Attempting to extract current version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json using sed...
[2026-03-30 12:13:19] Successfully extracted version using sed: 5.0.0
[2026-03-30 12:13:19] Current version detected in VERSION.json: 5.0.0
[2026-03-30 12:13:19] Attempting to extract current stage from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json using sed...
[2026-03-30 12:13:19] Successfully extracted stage using sed: alpha0
[2026-03-30 12:13:19] Current stage detected in VERSION.json: alpha0
[2026-03-30 12:13:19] Attempting to extract current revision from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json using sed...
[2026-03-30 12:13:19] Successfully extracted revision using sed: 00
[2026-03-30 12:13:19] Current revision detected in package.json: 00
[2026-03-30 12:13:19] Default revision set to: 00
[2026-03-30 12:13:19] Comparing new version (5.1.0) with current version (5.0.0)...
[2026-03-30 12:13:19] Version check passed: New version (5.1.0) is greater than current version (5.0.0) (Minor increased).
[2026-03-30 12:13:19] Final revision determined: 00
[2026-03-30 12:13:19] Freeze mode enabled: version values and branch references will be updated.
[2026-03-30 12:13:19] Starting file modifications...
[2026-03-30 12:13:19] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json
[2026-03-30 12:13:19] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json with new version: 5.1.0 and stage: alpha1
[2026-03-30 12:13:19] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json
[2026-03-30 12:13:19] Attempting to update version to 5.1.0 within 'wazuh' object in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json
[2026-03-30 12:13:19] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json with new version: 5.1.0 and revision: 00
[2026-03-30 12:13:19] Updating CHANGELOG.md...
[2026-03-30 12:13:19] Attempting to extract .version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json using sed (Note: This is fragile)
[2026-03-30 12:13:19] Detected OpenSearch Dashboards version for changelog: 3.3.0
[2026-03-30 12:13:19] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-03-30 12:13:19] CHANGELOG.md updated successfully.
[2026-03-30 12:13:19] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml
[2026-03-30 12:13:19] Attempting to update default reference to 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml
[2026-03-30 12:13:19] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml with new default reference: 5.1.0
[2026-03-30 12:13:19] Updating /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml workflow...
[2026-03-30 12:13:19] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml (where applicable)
[2026-03-30 12:13:19] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-03-30 12:13:19] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/unit-tests-workflow.yml (where applicable)
[2026-03-30 12:13:19] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/lint-workflow.yml (where applicable)
[2026-03-30 12:13:19] File modifications completed.
[2026-03-30 12:13:19] Repository bump completed successfully. Log file: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/tools/repository_bumper_2026-03-30_12-13-19-674.log

```

</p>
</details> 

<details><summary>Running: <code>./tools/repository_bumper.sh  --version 5.1.0 --stage alpha1 --set-as-main</code></summary>
<p>

```bash
wazuh-dashboard-ml-commons change/30-add-set-as-main-flag-support-to-repository-bumper-wazuh-dashboard-ml-commons ❯ ./tools/repository_bumper.sh --version 5.1.0 --stage alpha1 --set-as-main
[2026-03-30 12:12:44] Starting repository bump process
[2026-03-30 12:12:44] Repository path: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons
[2026-03-30 12:12:44] Version: 5.1.0
[2026-03-30 12:12:44] Stage: alpha1
[2026-03-30 12:12:44] Attempting to extract current version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json using sed...
[2026-03-30 12:12:44] Successfully extracted version using sed: 5.0.0
[2026-03-30 12:12:44] Current version detected in VERSION.json: 5.0.0
[2026-03-30 12:12:44] Attempting to extract current stage from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json using sed...
[2026-03-30 12:12:44] Successfully extracted stage using sed: alpha0
[2026-03-30 12:12:44] Current stage detected in VERSION.json: alpha0
[2026-03-30 12:12:44] Attempting to extract current revision from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json using sed...
[2026-03-30 12:12:44] Successfully extracted revision using sed: 00
[2026-03-30 12:12:44] Current revision detected in package.json: 00
[2026-03-30 12:12:44] Default revision set to: 00
[2026-03-30 12:12:44] Comparing new version (5.1.0) with current version (5.0.0)...
[2026-03-30 12:12:44] Version check passed: New version (5.1.0) is greater than current version (5.0.0) (Minor increased).
[2026-03-30 12:12:44] Final revision determined: 00
[2026-03-30 12:12:44] Main branch mode enabled: version values will be updated and branch references will remain pointing to main.
[2026-03-30 12:12:44] Starting file modifications...
[2026-03-30 12:12:44] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json
[2026-03-30 12:12:44] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/VERSION.json with new version: 5.1.0 and stage: alpha1
[2026-03-30 12:12:44] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json
[2026-03-30 12:12:44] Attempting to update version to 5.1.0 within 'wazuh' object in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json
[2026-03-30 12:12:44] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json with new version: 5.1.0 and revision: 00
[2026-03-30 12:12:44] Updating CHANGELOG.md...
[2026-03-30 12:12:44] Attempting to extract .version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/package.json using sed (Note: This is fragile)
[2026-03-30 12:12:44] Detected OpenSearch Dashboards version for changelog: 3.3.0
[2026-03-30 12:12:44] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-03-30 12:12:44] CHANGELOG.md updated successfully.
[2026-03-30 12:12:44] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml
[2026-03-30 12:12:44] Attempting to update default reference to 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml
[2026-03-30 12:12:44] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml with new default reference: 5.1.0
[2026-03-30 12:12:44] Updating /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/.github/workflows/5_builderpackage_ml_commons_plugin.yml workflow...
[2026-03-30 12:12:44] skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged
[2026-03-30 12:12:44] File modifications completed.
[2026-03-30 12:12:44] Repository bump completed successfully. Log file: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-ml-commons/tools/repository_bumper_2026-03-30_12-12-44-640.log

```

</p>
</details> 

### Testing
- Try running the commands specified in evidence and look at the output log created.

### Check List
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff